### PR TITLE
Update getWeth.ts

### DIFF
--- a/scripts/getWeth.ts
+++ b/scripts/getWeth.ts
@@ -7,7 +7,6 @@ export const AMOUNT = (ethers.utils.parseEther("0.1")).toString()
 export async function getWeth() {
     const { deployer } = await getNamedAccounts()
     const iWeth = await ethers.getContractAt(
-        "IWeth",
         networkConfig[network.config!.chainId!].wethToken!,
         deployer
     )


### PR DESCRIPTION
Removed the `"IWETH"` as it was showing as an error. When I've looked at the `hardhat.d.ts` file inside of `typechain-types/factories` it shows that the `name` parameter is already filled, I presume once it's been compiled?
<img width="1372" alt="Screenshot 2022-10-19 at 10 53 22" src="https://user-images.githubusercontent.com/67101320/196659927-874be611-b252-42b7-b9ac-23789a6955c2.png">