### PR TITLE
Dai PriceFeed  Mistake

### DIFF
--- a/helper-hardhat-config.js
+++ b/helper-hardhat-config.js
@@ -5,6 +5,7 @@ const networkConfig = {
         lendingPoolAddressesProvider: "0xB53C1a33016B2DC2fF3653530bfF1848a515c8c5",
         daiEthPriceFeed: "0x773616E4d11A78F511299002da57A0a94577F1f4",
         daiToken: "0x6b175474e89094c44da98b954eedeac495271d0f",
+        daiUSDPriceFeed: "0xAed0c38402a5d19df6E4c03F4E2DceD6e29c1ee9",
     },
     // Due to the changing testnets, this testnet might not work as shown in the video
     5: {

--- a/scripts/aaveBorrow.js
+++ b/scripts/aaveBorrow.js
@@ -14,7 +14,8 @@ async function main() {
     // Getting your borrowing stats
     let { availableBorrowsETH, totalDebtETH } = await getBorrowUserData(lendingPool, deployer)
     const daiPrice = await getDaiPrice()
-    const amountDaiToBorrow = availableBorrowsETH.toString() * 0.95 * (1 / daiPrice.toNumber())
+    // PriceFeed here should be DAI/USD, so that we can get amount dai to borrow
+    const amountDaiToBorrow = availableBorrowsETH.toString() * 0.95 * (1 / daiPrice.toNumber()) 
     const amountDaiToBorrowWei = ethers.utils.parseEther(amountDaiToBorrow.toString())
     console.log(`You can borrow ${amountDaiToBorrow.toString()} DAI`)
     await borrowDai(
@@ -49,10 +50,10 @@ async function borrowDai(daiAddress, lendingPool, amountDaiToBorrow, account) {
 async function getDaiPrice() {
     const daiEthPriceFeed = await ethers.getContractAt(
         "AggregatorV3Interface",
-        networkConfig[network.config.chainId].daiEthPriceFeed
+        networkConfig[network.config.chainId].daiUSDPriceFeed
     )
     const price = (await daiEthPriceFeed.latestRoundData())[1]
-    console.log(`The DAI/ETH price is ${price.toString()}`)
+    console.log(`The DAI/USD price is ${price.toString()}`)
     return price
 }
 

--- a/scripts/aaveBorrow.js
+++ b/scripts/aaveBorrow.js
@@ -50,7 +50,7 @@ async function borrowDai(daiAddress, lendingPool, amountDaiToBorrow, account) {
 async function getDaiPrice() {
     const daiEthPriceFeed = await ethers.getContractAt(
         "AggregatorV3Interface",
-        networkConfig[network.config.chainId].daiUSDPriceFeed
+        networkConfig[network.config.chainId].daiUSDPriceFeed //update PriceFeed
     )
     const price = (await daiEthPriceFeed.latestRoundData())[1]
     console.log(`The DAI/USD price is ${price.toString()}`)


### PR DESCRIPTION
The `getDaiPrice` function should use `DAI/USD` instead of `DAI/ETH` price feed address so that the calculation in the main function should get the wrong amount of DAI to borrow. Additionally, add the DAI/ETH chainlink price feed address to the helper-hardhat-config file.